### PR TITLE
Cleaned up deprecated function calls

### DIFF
--- a/copy_this/modules/carrier_tracking/controllers/admin/carrier_main.php
+++ b/copy_this/modules/carrier_tracking/controllers/admin/carrier_main.php
@@ -73,8 +73,8 @@ class Carrier_Main extends oxAdminDetails
     public function save()
     {
         parent::save();
-        $soxId      = oxConfig::getParameter("oxid");
-        $aParams    = oxConfig::getParameter("editval");
+        $soxId      = oxRegistry::getConfig()->getRequestParameter("oxid");
+        $aParams    = oxRegistry::getConfig()->getRequestParameter("editval");
 
         // checkbox handling
         if (!isset($aParams['oxcarriers__oxactive'])) {
@@ -122,8 +122,8 @@ class Carrier_Main extends oxAdminDetails
      */
     public function saveinnlang()
     {
-        $soxId      = oxConfig::getParameter( "oxid");
-        $aParams    = oxConfig::getParameter( "editval");
+        $soxId      = oxRegistry::getConfig()->getRequestParameter( "oxid");
+        $aParams    = oxRegistry::getConfig()->getRequestParameter( "editval");
         // checkbox handling
         if (!isset($aParams['oxcarriers__oxactive'])) {
             $aParams['oxcarriers__oxactive'] = 0;
@@ -171,7 +171,7 @@ class Carrier_Main extends oxAdminDetails
         }
 
         $sOxId = $this->getEditObjectId();
-        $sField = oxConfig::getParameter('masterPicField');
+        $sField = oxRegistry::getConfig()->getRequestParameter('masterPicField');
         if (empty($sField)) {
             return;
         }


### PR DESCRIPTION
In OXID Versions > 4.9 there have been removed some deprecated functions. This leads to a broken module, especially in the backend while doing administrative tasks on the carriers. 

These bugs are fixed in here and the module works again as it did before. (Tested with 4.9.3 and some 4.8.x)
